### PR TITLE
Expand README with PostgreSQL's `synchronous_commit`

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ To wait for replication on every mutation, configure the primary database connec
 
 ```diff
 -import { Kysely, PostgresDialect } from 'kysely'
-+import { Kysely, PostgresDialect, sql } from 'kysely'
++import { CompiledQuery, Kysely, PostgresDialect } from 'kysely'
 import { KyselyReplicationDialect } from 'kysely-replication'
 import { RoundRobinReplicaStrategy } from 'kysely-replication/strategy/round-robin'
 import { Pool } from 'pg'
@@ -164,7 +164,7 @@ import { Pool } from 'pg'
 const primaryDialect = new PostgresDialect({
     pool: new Pool({ connectionString: process.env.DATABASE_URL_PRIMARY }),
 +   onCreateConnection: async (connection) => {
-+       await sql`set synchronous_commit = 'remote_apply'`.execute(connection)
++       await connection.executeQuery(CompiledQuery.raw(`set synchronous_commit = 'remote_apply'`))
 +   },
 })
 ```

--- a/README.md
+++ b/README.md
@@ -156,10 +156,10 @@ To wait for replication on every mutation, configure the primary database connec
 
 ```diff
 const primaryDialect = new PostgresDialect({
-  pool: new Pool({ connectionString: process.env.DATABASE_URL_PRIMARY }),
-+  onCreateConnection: async connnection => {
-+    await connnection.executeQuery(CompiledQuery.raw(`SET synchronous_commit = 'remote_apply'`))
-+  },
+    pool: new Pool({ connectionString: process.env.DATABASE_URL_PRIMARY }),
++   onCreateConnection: async connnection => {
++       await connnection.executeQuery(CompiledQuery.raw(`SET synchronous_commit = 'remote_apply'`))
++   },
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -143,3 +143,36 @@ const users = await db
   .values({ email: 'info@example.com', is_verified: false })
   .execute() // executes on replica 2 instead of primary
 ```
+
+## Wait for Propagation (PostgreSQL-Only)
+
+When writing to the primary, you may want to ensure that replicas have caught up before considering a mutation as complete. This can be critical for consistency in systems that rely on replicated reads immediately following a write.
+
+Replication is usually near-instantaneous but can occasionally take longer (e.g., 30+ seconds). Therefore, waiting for replication increases mutation execution time, so use this approach selectively where required.
+
+### All Mutations
+
+To wait for replication on every mutation, configure the primary database connection:
+
+```ts
+const primaryDialect = new PostgresDialect({
+    pool: new Pool({ connectionString: process.env.DATABASE_URL_PRIMARY }),
+    onCreateConnection: async connnection => {
+    // Apply setting globally for this connection (PostgreSQL)
+    await connnection.executeQuery(CompiledQuery.raw(`SET synchronous_commit = 'remote_apply'`))
+  },
+})
+```
+
+### Ad-Hoc Mutations
+
+If waiting for replication is only required for specific operations, use SET LOCAL within a transaction. This scopes the setting to the transaction without affecting the connection’s global state.
+
+```ts
+await db.transaction().execute(async tx => {
+  // Set synchronous_commit for this transaction only (PostgreSQL)
+  tx.executeQuery(CompiledQuery.raw(`SET LOCAL synchronous_commit = 'remote_apply'`))
+
+  // continue with the transaction as normal
+})
+```

--- a/README.md
+++ b/README.md
@@ -154,13 +154,12 @@ Replication is usually near-instantaneous but can occasionally take longer (e.g.
 
 To wait for replication on every mutation, configure the primary database connection:
 
-```ts
+```diff
 const primaryDialect = new PostgresDialect({
-    pool: new Pool({ connectionString: process.env.DATABASE_URL_PRIMARY }),
-    onCreateConnection: async connnection => {
-    // Apply setting globally for this connection (PostgreSQL)
-    await connnection.executeQuery(CompiledQuery.raw(`SET synchronous_commit = 'remote_apply'`))
-  },
+  pool: new Pool({ connectionString: process.env.DATABASE_URL_PRIMARY }),
++  onCreateConnection: async connnection => {
++    await connnection.executeQuery(CompiledQuery.raw(`SET synchronous_commit = 'remote_apply'`))
++  },
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -155,10 +155,16 @@ Replication is usually near-instantaneous but can occasionally take longer (e.g.
 To wait for replication on every mutation, configure the primary database connection:
 
 ```diff
+-import { Kysely, PostgresDialect } from 'kysely'
++import { Kysely, PostgresDialect, sql } from 'kysely'
+import { KyselyReplicationDialect } from 'kysely-replication'
+import { RoundRobinReplicaStrategy } from 'kysely-replication/strategy/round-robin'
+import { Pool } from 'pg'
+
 const primaryDialect = new PostgresDialect({
     pool: new Pool({ connectionString: process.env.DATABASE_URL_PRIMARY }),
-+   onCreateConnection: async connnection => {
-+       await connnection.executeQuery(CompiledQuery.raw(`SET synchronous_commit = 'remote_apply'`))
++   onCreateConnection: async (connection) => {
++       await sql`set synchronous_commit = 'remote_apply'`.execute(connection)
 +   },
 })
 ```

--- a/README.md
+++ b/README.md
@@ -174,9 +174,10 @@ const primaryDialect = new PostgresDialect({
 If waiting for replication is only required for specific operations, use SET LOCAL within a transaction. This scopes the setting to the transaction without affecting the connection’s global state.
 
 ```ts
-await db.transaction().execute(async tx => {
-  // Set synchronous_commit for this transaction only (PostgreSQL)
-  tx.executeQuery(CompiledQuery.raw(`SET LOCAL synchronous_commit = 'remote_apply'`))
+import { sql } from 'kysely'
+
+await db.transaction().execute(async (trx) => {
+  await sql`set local synchronous_commit = 'remote_apply'`.execute(trx)
 
   // continue with the transaction as normal
 })


### PR DESCRIPTION
Adding an example of how to use PostgreSQL's `synchronous_commit` to wait for replication to replicas before considering a mutation as completed