### PR TITLE
Include prototype augmentation in the build

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,9 @@
 		"typescript": "^5.7.2",
 		"vitest": "^2.1.8"
 	},
-	"sideEffects": false,
+	"sideEffects": [
+		"./src/force/module-augmentation.ts"
+	],
 	"packageManager": "pnpm@9.15.1+sha512.1acb565e6193efbebda772702950469150cf12bcc764262e7587e71d19dc98a423dff9536e57ea44c49bdf790ff694e83c27be5faa23d67e0c033b583be4bfcf",
 	"exports": {
 		"./package.json": "./package.json",


### PR DESCRIPTION
Fixes https://github.com/kysely-org/kysely-replication/issues/2

The prototype augmentation is otherwise lost in the build step, so including `import 'kysely-replication/force'` doesn't monkey patch anything, it merely defines the module augmentation, but the underlying function is missing.