### PR TITLE
fix sideEffects file paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
 		"vitest": "^4.0.3"
 	},
 	"sideEffects": [
-		"./src/force/module-augmentation.mts"
+		"./dist/force/index.js",
+		"./dist/force/index.cjs"
 	],
 	"exports": {
 		"./package.json": "./package.json",


### PR DESCRIPTION
Update `sideEffects` to the correct package paths to fix the following esbuild warning in consuming projects:

```
 WARN  ▲ [WARNING] Ignoring this import because "node_modules/kysely-replication/dist/force/index.js" was marked as having no side effects [ignored-bare-import]

    src/data/replication.ts:5:7:
      5 │ import 'kysely-replication/force';
        ╵        ~~~~~~~~~~~~~~~~~~~~~~~~~~

  It was excluded from the "sideEffects" array in the enclosing "package.json" file:

    node_modules/kysely-replication/package.json:45:2:
      45 │   "sideEffects": [
         ╵   ~~~~~~~~~~~~~
```

Related to #3